### PR TITLE
Various fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "bsb -make-world -backend native",
     "postinstall": "bsb -make-world -backend native",
+    "watch": "bsb -make-world -backend native -w",
     "test": "./lib/bs/native/syntax_test.native",
     "clean": "bsb -clean-world"
   },

--- a/src/Devtools.re
+++ b/src/Devtools.re
@@ -6,10 +6,11 @@ open Migrate_parsetree.Ast_403;
 let config = {
   prefix: [%str
     external to_devtools: 'a => Js.t {.} = "%identity";
+    let unit__to_devtools = to_devtools;
     let int__to_devtools = to_devtools;
     let float__to_devtools = to_devtools;
     let string__to_devtools = to_devtools;
-    let boolean__to_devtools = to_devtools;
+    let bool__to_devtools = to_devtools;
     let list__to_devtools convert items => {
       "$bs": "list",
       "items": List.map convert items |> Array.of_list


### PR DESCRIPTION
1. Add `watch` script for convenience
2. Fix boolean convertors so they work with OCaml `bool`
3. Add unit convertor. Not that serializing a unit is very useful, but I've found it useful for functors that take in a type with a `__to/from_json` function
4. Add `noserialize` attribute for types in module signatures